### PR TITLE
[FIX]: generate_query_results looks for the specific qry_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__
 
 .venv
+venv/
+.vscode/
 
 build/
 dist/

--- a/redashAPI/client.py
+++ b/redashAPI/client.py
@@ -68,10 +68,11 @@ class RedashAPIClient(object):
         return self.post(f"queries/{qry_id}/refresh")
 
     def generate_query_results(self, qry_id: int):
-        res = self.get('queries')
-        results = res.json().get('results', [])
+        res = self.get(f'queries/{qry_id}')
+        res_data = res.json()
 
-        ds_id, qry = next(((q['data_source_id'], q['query']) for q in results if q['id'] == qry_id), (None, None))
+        ds_id = res_data.get('data_source_id', None)
+        qry = res_data.get('query', None)
 
         if ds_id is None or qry is None:
             raise Exception("Query not found.")


### PR DESCRIPTION
The previous way brings the information of the redash `querys paginated` and tries to find the `qry_id` from the result

If a user has too many querys stored and the specific `qry_id` can be found in a page diferent from the first, the method will respond with a `Query not found` which is not true